### PR TITLE
Add type to environment to detect type mismatches

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -5,7 +5,7 @@ export interface Environment {
   toDoApi: ToDoApi
 }
 
-export const environment = {
+export const environment: Environment = {
   toDoApi,
 }
 


### PR DESCRIPTION
This way we can detect if the environment variable is of a different type than the Environment type and prevent some errors. This would be relevant if the environment gets complex.